### PR TITLE
Fix report

### DIFF
--- a/R/freqAnalysis.R
+++ b/R/freqAnalysis.R
@@ -161,9 +161,9 @@ freqAnalysisServer <- function(id, data, FixRand, outcome, ContBin, Pair_trt, Pa
           withProgress(message = 'Generating file...', value = 0.5, {
           
           if (FixRand()=='fixed') {
-            file.copy(reporter(freqpair()$MA$MA.Fixed, open = FALSE, dir = "~"), file)
+            file.copy(reporter(freqpair()$MA$MA.Fixed, filename="report", open = FALSE), file)
           } else {
-            file.copy(reporter(freqpair()$MA$MA.Random, open = FALSE, dir = "~"), file)
+            file.copy(reporter(freqpair()$MA$MA.Random, filename="report", open = FALSE), file)
           }
             
             setProgress(message = 'File generated', value = 1)


### PR DESCRIPTION
Unix based OS's do not support special characters i.e. `()`, when knitting via pandoc, therefore the default filename used by reported (`freqpair()$MA$MA.Fixed`) does not work. I have therefore supplied a filename to the generated report.

Note: I have removed the `dir` parameter as by default this should be using temporary directories.