### PR TITLE
Hotfix/enable odds ratio only

### DIFF
--- a/R/bayesAnalysis.R
+++ b/R/bayesAnalysis.R
@@ -4,14 +4,13 @@ bayesAnalysisUI <- function(id) {
     fluidRow(
       align="center",
       br(),
-      shinyjs::disabled(
-        actionButton(
-          inputId = ns("BayesRun"),
-          label = "Run Bayesian meta-analysis",
-          class = "btn-primary btn-lg"
-        )
+      actionButton(
+        inputId = ns("BayesRun"),
+        label = "Run Bayesian meta-analysis",
+        class = "btn-primary btn-lg"
       ),
       div(
+        id=ns("bayes_warning"),
         "Bayesian analysis has been temporarily disabled due to a code issue.",
         span(
           "See the ",
@@ -179,6 +178,17 @@ bayesAnalysisServer <- function(id, data, FixRand, outcome, ContBin, Pair_trt, P
           trt = Pair_trt()
         )
       })
+      
+      observe({
+        if (outcome() == "RR" || outcome() == "RD") {
+          shinyjs::disable("BayesRun")
+          shinyjs::show("bayes_warning")
+        } else {
+          shinyjs::enable("BayesRun")
+          shinyjs::hide("bayes_warning")
+        }
+      })
+      
       
       bayespair <- eventReactive(
         input$BayesRun,

--- a/R/bayesAnalysis.R
+++ b/R/bayesAnalysis.R
@@ -11,7 +11,7 @@ bayesAnalysisUI <- function(id) {
       ),
       div(
         id=ns("bayes_warning"),
-        "Bayesian analysis has been temporarily disabled due to a code issue.",
+        "Bayesian analysis has been temporarily disabled for this outcome due to a code issue.",
         span(
           "See the ",
           tags$a(

--- a/R/frontPage.R
+++ b/R/frontPage.R
@@ -5,7 +5,7 @@
 frontPageUI <- function(id) {
   div(
     h2(
-      "MetaPairwise V1.1.1",
+      "MetaPairwise V1.1.2",
       tags$sup("Beta", style = "color:#6CC0ED"), 
       align = "left"
     ),
@@ -29,9 +29,9 @@ frontPageUI <- function(id) {
         ),
         hr(),
         p(tags$strong("Latest Updates:")),
-        p(tags$strong("Patch update (14th May 2025 v1.1.1-beta):")),
+        p(tags$strong("Patch update (28th January 2026 v1.1.2-beta):")),
         tags$ul(
-          tags$li("Disabled bayesian analysis temporarily."),
+          tags$li("Enabled only odd ration outcome for bayesian analysis."),
           tags$ul(
             tags$li(
               "See the ",

--- a/R/frontPage.R
+++ b/R/frontPage.R
@@ -31,7 +31,7 @@ frontPageUI <- function(id) {
         p(tags$strong("Latest Updates:")),
         p(tags$strong("Patch update (28th January 2026 v1.1.2-beta):")),
         tags$ul(
-          tags$li("Enabled only odd ration outcome for bayesian analysis."),
+          tags$li("Enabled odds ratio outcome for bayesian analysis. Risk ratio and risk different remain disabled."),
           tags$ul(
             tags$li(
               "See the ",


### PR DESCRIPTION
Enabled odd ration for bayesian and disabled risk ratio and risk difference. Part of ongoing issue #22